### PR TITLE
[Feat] 검색 페이지 UI 퍼블리싱

### DIFF
--- a/app/search/index.tsx
+++ b/app/search/index.tsx
@@ -1,0 +1,46 @@
+import {
+  Container,
+  OptionLayer,
+  Overlay,
+  StyledScrollView,
+  StyledSearchBar,
+  SubText,
+} from './searchScreen.styled';
+
+import SortButton from '@/components/common/sortButton/SortButton';
+import SortModal from '@/components/common/sortModal/SortModal';
+import TabBar from '@/components/common/tabBar/TabBar';
+import CategoryItemWrapper from '@/components/consumer/categoryItem/CategoryItemWrapper';
+import { useLocalSearchParams } from 'expo-router';
+import { useState } from 'react';
+
+export default function SearchScreen() {
+  const [isModalOn, setIsModalOn] = useState<boolean>(false);
+  const [option, setOption] = useState<'latest' | 'price'>('latest');
+  const { query } = useLocalSearchParams();
+  const [value, setValue] = useState<string>(query[0]);
+  return (
+    <>
+      <Container>
+        <StyledSearchBar value={value} setValue={setValue} />
+        <OptionLayer>
+          <SubText>{value}와 관련된 검색입니다.</SubText>
+          <SortButton
+            option={option}
+            isModalOn={isModalOn}
+            setIsModalOn={setIsModalOn}
+          />
+        </OptionLayer>
+        <StyledScrollView>
+          <CategoryItemWrapper />
+        </StyledScrollView>
+      </Container>
+      <TabBar />
+      {isModalOn && (
+        <Overlay onPress={() => setIsModalOn(false)}>
+          <SortModal option={option} setOption={setOption} />
+        </Overlay>
+      )}
+    </>
+  );
+}

--- a/app/search/searchScreen.styled.ts
+++ b/app/search/searchScreen.styled.ts
@@ -1,0 +1,52 @@
+import { Dimensions, ScrollView } from 'react-native';
+
+import SearchBar from '@/components/common/searchBar/SearchBar';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import styled from 'styled-components/native';
+
+export const Container = styled(SafeAreaView)`
+  padding-top: 20px;
+  flex: 1;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  background-color: #fff;
+`;
+
+export const StyledSearchBar = styled(SearchBar)`
+  width: 100%;
+`;
+
+export const OptionLayer = styled.View`
+  display: flex;
+  height: 70px;
+  padding: 15px;
+  width: 80%;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+export const SubText = styled.Text`
+  width: 60%;
+`;
+
+export const StyledScrollView = styled(ScrollView)`
+  width: 100%;
+`;
+
+const { width, height } = Dimensions.get('window');
+
+export const Overlay = styled.TouchableOpacity`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: ${width}px;
+  height: ${height}px;
+  background-color: rgba(0, 0, 0, 0.4);
+  z-index: 1;
+  justify-content: center;
+  align-items: center;
+`;

--- a/components/common/mainHeader/mainHeader.styled.ts
+++ b/components/common/mainHeader/mainHeader.styled.ts
@@ -9,6 +9,7 @@ export const Container = styled(SafeAreaView).attrs({
   flex-direction: column;
   justify-content: start;
   align-items: center;
+  z-index: 2;
 `;
 
 export const TextWrapper = styled.View`

--- a/components/common/searchBar/SearchBar.tsx
+++ b/components/common/searchBar/SearchBar.tsx
@@ -5,12 +5,15 @@ import {
   SearchIcon,
 } from './searchBar.styled';
 
+import { useRouter } from 'expo-router';
+
 type Props = {
   value: string;
   setValue: (value: string) => void;
 };
 
 export default function SearchBar({ value, setValue }: Props) {
+  const route = useRouter();
   return (
     <Container>
       <InputBar>
@@ -19,7 +22,11 @@ export default function SearchBar({ value, setValue }: Props) {
           value={value}
           onChangeText={setValue}
         />
-        <SearchIcon />
+        <SearchIcon
+          onPress={() =>
+            route.push(`/search?query=${encodeURIComponent(value)}`)
+          }
+        />
       </InputBar>
     </Container>
   );

--- a/components/common/sortButton/SortButton.tsx
+++ b/components/common/sortButton/SortButton.tsx
@@ -1,23 +1,21 @@
 import { Container, StyledText, StyledTouchable } from './sortButton.styled';
 
-import { useState } from 'react';
-
 type Props = {
+  option: 'latest' | 'price';
   isModalOn: boolean;
   setIsModalOn: (data: boolean) => void;
 };
 
-export default function SortButton({ isModalOn, setIsModalOn }: Props) {
-  const [sortType, setSortType] = useState<'latest' | 'dictionary'>('latest');
+export default function SortButton({ option, isModalOn, setIsModalOn }: Props) {
   const mappingKorean = (data: string) => {
-    if (data === 'latest') return '최신순';
-    if (data === 'dictionary') return '사전순';
+    if (option === 'latest') return '최신순';
+    if (option === 'price') return '가격순';
   };
 
   return (
     <StyledTouchable onPress={() => setIsModalOn(!isModalOn)}>
       <Container>
-        <StyledText>{mappingKorean(sortType)}</StyledText>
+        <StyledText>{mappingKorean(option)}</StyledText>
       </Container>
     </StyledTouchable>
   );

--- a/components/common/sortButton/SortButton.tsx
+++ b/components/common/sortButton/SortButton.tsx
@@ -1,0 +1,24 @@
+import { Container, StyledText, StyledTouchable } from './sortButton.styled';
+
+import { useState } from 'react';
+
+type Props = {
+  isModalOn: boolean;
+  setIsModalOn: (data: boolean) => void;
+};
+
+export default function SortButton({ isModalOn, setIsModalOn }: Props) {
+  const [sortType, setSortType] = useState<'latest' | 'dictionary'>('latest');
+  const mappingKorean = (data: string) => {
+    if (data === 'latest') return '최신순';
+    if (data === 'dictionary') return '사전순';
+  };
+
+  return (
+    <StyledTouchable onPress={() => setIsModalOn(!isModalOn)}>
+      <Container>
+        <StyledText>{mappingKorean(sortType)}</StyledText>
+      </Container>
+    </StyledTouchable>
+  );
+}

--- a/components/common/sortButton/sortButton.styled.ts
+++ b/components/common/sortButton/sortButton.styled.ts
@@ -1,0 +1,24 @@
+import { TouchableOpacity } from 'react-native';
+import styled from 'styled-components/native';
+
+export const StyledTouchable = styled(TouchableOpacity)`
+  position: relative;
+`;
+
+export const Container = styled.View`
+  width: 100px;
+  height: 40px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background-color: #fff;
+  border-color: #d9d9d9;
+  border-width: 1px;
+  border-radius: 20px;
+`;
+
+export const StyledText = styled.Text`
+  color: #000;
+  font-weight: 700;
+`;

--- a/components/common/sortModal/SortModal.tsx
+++ b/components/common/sortModal/SortModal.tsx
@@ -1,0 +1,30 @@
+import {
+  Bar,
+  Container,
+  OptionBar,
+  OptionText,
+  StyledCheck,
+  TitleText,
+} from './sortModal.styled';
+
+type Props = {
+  option: 'latest' | 'price';
+  setOption: (op: 'latest' | 'price') => void;
+};
+
+export default function SortModal({ option, setOption }: Props) {
+  return (
+    <Container>
+      <Bar />
+      <TitleText>정렬</TitleText>
+      <OptionBar onPress={() => setOption('latest')}>
+        <OptionText isActive={option === 'latest'}>최신순</OptionText>
+        <StyledCheck isActive={option === 'latest'} />
+      </OptionBar>
+      <OptionBar onPress={() => setOption('price')}>
+        <OptionText isActive={option === 'price'}>가격순</OptionText>
+        <StyledCheck isActive={option === 'price'} />
+      </OptionBar>
+    </Container>
+  );
+}

--- a/components/common/sortModal/sortModal.styled.ts
+++ b/components/common/sortModal/sortModal.styled.ts
@@ -1,0 +1,57 @@
+import { Check } from 'lucide-react-native';
+import styled from 'styled-components/native';
+
+export const Container = styled.View`
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background-color: #fff;
+  border-top-left-radius: 25px;
+  border-top-right-radius: 25px;
+  gap: 10px;
+  padding-top: 20px;
+  padding-right: 20px;
+  padding-left: 20px;
+  padding-bottom: 80px;
+`;
+
+export const Bar = styled.View`
+  width: 50px;
+  height: 5px;
+  background-color: #d9d9d9;
+  border-radius: 10px;
+  margin-top: 10px;
+  margin-bottom: 20px;
+`;
+
+export const TitleText = styled.Text`
+  font-size: 25px;
+  font-weight: 700;
+  padding-bottom: 20px;
+`;
+
+export const OptionBar = styled.TouchableOpacity`
+  display: flex;
+  width: 100%;
+  height: 30px;
+  padding-right: 20px;
+  padding-left: 20px;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+export const OptionText = styled.Text<{ isActive: boolean }>`
+  font-size: 18px;
+  font-weight: 600;
+  color: ${(props) => (props.isActive ? '#30DB5B' : '#000')};
+`;
+
+export const StyledCheck = styled(Check)<{ isActive: boolean }>`
+  display: ${(props) => (props.isActive ? 'flex' : 'none')};
+  color: ${(props) => (props.isActive ? '#30DB5B' : '')};
+`;

--- a/components/consumer/categoryBox/categoryBox.styled.ts
+++ b/components/consumer/categoryBox/categoryBox.styled.ts
@@ -2,7 +2,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import styled from 'styled-components/native';
 
 export const Container = styled(SafeAreaView)`
-  height: 240px;
+  height: 280px;
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/components/consumer/categoryBox/categoryBox.styled.ts
+++ b/components/consumer/categoryBox/categoryBox.styled.ts
@@ -2,7 +2,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import styled from 'styled-components/native';
 
 export const Container = styled(SafeAreaView)`
-  height: 280px;
+  height: 330px;
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/components/consumer/categoryItem/CategoryItemWrapper.tsx
+++ b/components/consumer/categoryItem/CategoryItemWrapper.tsx
@@ -57,7 +57,7 @@ const dummyData = [
     title: '상추 200g',
     price: '₩1,000',
     sellerName: '장채소',
-    sellerImage: 'https://example.com/sellers/jang.jpg',
+    sellerImage: '',
   },
   {
     imgUrl:

--- a/components/consumer/categoryItem/categoryItemWrapper.styled.ts
+++ b/components/consumer/categoryItem/categoryItemWrapper.styled.ts
@@ -5,7 +5,7 @@ export const Container = styled.View`
   width: 100%;
   display: flex;
   flex-direction: column;
-  justify-content: flex-start;
+  justify-content: center;
   align-items: center;
 `;
 
@@ -14,6 +14,6 @@ export const ItemsContainer = styled.View`
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
-  justify-content: flex-start;
-  align-items: flex-start;
+  justify-content: center;
+  align-items: center;
 `;

--- a/components/consumer/categoryItem/categoryItemWrapper.styled.ts
+++ b/components/consumer/categoryItem/categoryItemWrapper.styled.ts
@@ -1,21 +1,19 @@
-import { SafeAreaView } from 'react-native-safe-area-context';
 import styled from 'styled-components/native';
 
-export const Container = styled(SafeAreaView)`
+export const Container = styled.View`
   flex: 1;
   width: 100%;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center;
 `;
 
 export const ItemsContainer = styled.View`
-  flex: 1;
   width: 80%;
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
-  justify-content: space-between;
+  justify-content: flex-start;
   align-items: flex-start;
 `;

--- a/components/consumer/itemComponent/itemComponent.styled.ts
+++ b/components/consumer/itemComponent/itemComponent.styled.ts
@@ -1,9 +1,13 @@
 import { Image } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import styled from 'styled-components/native';
 
-export const Container = styled(SafeAreaView)`
+export const Container = styled.View`
   width: 50%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 20px;
 `;
 
 export const ImgBox = styled(Image)`


### PR DESCRIPTION
## #️⃣연관된 이슈

> #7 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 검색 키워드 연결하여 페이지 이동
- 정렬 버튼 컴포넌트 생성
- 정렬 모달 컴포넌트 생성

### 스크린샷
| 화면 | 스크린샷 |
|------|-----------|
| 검색 메인 페이지 | <img src="https://github.com/user-attachments/assets/4e6ce65b-750d-43fe-a125-e7cb31ffee32" width="300"/> |
| 정렬 모달 | <img src="https://github.com/user-attachments/assets/74e126bf-a50f-48b5-8174-e49dd4eae32b" width="300"/> |
