### PR TITLE
[Feat] 농부 메인 페이지 UI 퍼블리싱

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.*
 
 # local env files
 .env*.local
+.env
 
 # typescript
 *.tsbuildinfo

--- a/app/farmer/FarmerMainScreen.styled.ts
+++ b/app/farmer/FarmerMainScreen.styled.ts
@@ -1,4 +1,16 @@
 import { SafeAreaView } from 'react-native-safe-area-context';
 import styled from 'styled-components/native';
 
-export const Container = styled(SafeAreaView)``;
+export const Container = styled(SafeAreaView).attrs({
+  edges: ['bottom', 'left', 'right'],
+})`
+  padding-top: 40px;
+  width: 100%;
+  flex: 1;
+  background-color: #fff;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 40px;
+`;

--- a/app/farmer/_layout.tsx
+++ b/app/farmer/_layout.tsx
@@ -1,0 +1,18 @@
+import { Stack } from 'expo-router';
+
+export default function Layout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShadowVisible: false,
+        headerTintColor: '#fff',
+        headerTitleAlign: 'center',
+        headerTitleStyle: {
+          color: '#30DB5B',
+          fontSize: 22,
+          fontWeight: 'bold',
+        },
+      }}
+    />
+  );
+}

--- a/app/farmer/index.tsx
+++ b/app/farmer/index.tsx
@@ -1,10 +1,22 @@
+import FeaturesBox from '@/components/farmer/featuresBox/FeaturesBox';
+import MyFarm from '@/components/farmer/myFarm/MyFarm';
+import SummaryBox from '@/components/seller/summaryBox/SummaryBox';
+import { Stack } from 'expo-router';
 import { Container } from './FarmerMainScreen.styled';
-import { Text } from 'react-native';
 
 export default function FarmerMainScreen() {
   return (
     <Container>
-      <Text>hi</Text>
+      <Stack.Screen options={{ title: '어글리 딜리셔스' }} />
+      <SummaryBox
+        imgUrl=''
+        name='미누리'
+        userType='farmer'
+        firstValue='0건'
+        secondValue='50,000원'
+      />
+      <MyFarm />
+      <FeaturesBox />
     </Container>
   );
 }

--- a/app/seller/[id].tsx
+++ b/app/seller/[id].tsx
@@ -1,12 +1,12 @@
 import { Container, SummaryArea } from './seller.styled';
 
+import TabBar from '@/components/common/tabBar/TabBar';
 import { ReviewItemProps } from '@/components/seller/reviewsBox/reviewItem/ReviewItem';
 import ReviewsBox from '@/components/seller/reviewsBox/ReviewsBox';
-import { ScrollView } from 'react-native';
 import SummaryBox from '@/components/seller/summaryBox/SummaryBox';
-import TabBar from '@/components/common/tabBar/TabBar';
 import TopHeader from '@/components/seller/topHeader/TopHeader';
 import { useLocalSearchParams } from 'expo-router';
+import { ScrollView } from 'react-native';
 
 const dummyReviews: ReviewItemProps[] = [
   {
@@ -49,7 +49,13 @@ export default function SellerScreen() {
         <Container>
           <TopHeader />
           <SummaryArea>
-            <SummaryBox imgUrl='' />
+            <SummaryBox
+              imgUrl=''
+              userType='user'
+              firstValue='0개'
+              name='홍길동'
+              secondValue='5점'
+            />
           </SummaryArea>
           <ReviewsBox data={dummyReviews} />
         </Container>

--- a/app/setFarmLocation/index.tsx
+++ b/app/setFarmLocation/index.tsx
@@ -1,0 +1,10 @@
+import { Text } from 'react-native';
+import { Container } from './setFarmLocation.styled';
+
+export default function SetFarmLocationScreen() {
+  return (
+    <Container>
+      <Text>Set Farm!</Text>
+    </Container>
+  );
+}

--- a/app/setFarmLocation/setFarmLocation.styled.ts
+++ b/app/setFarmLocation/setFarmLocation.styled.ts
@@ -1,0 +1,8 @@
+import { SafeAreaView } from 'react-native-safe-area-context';
+import styled from 'styled-components/native';
+
+export const Container = styled(SafeAreaView)`
+  flex: 1;
+  width: 100%;
+  background-color: #fff;
+`;

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,15 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: [
+      [
+        'module:react-native-dotenv',
+        {
+          moduleName: 'react-native-dotenv',
+          path: '.env',
+        },
+      ],
+    ],
+  };
+};

--- a/components/farmer/boxBlock/BoxBlock.tsx
+++ b/components/farmer/boxBlock/BoxBlock.tsx
@@ -1,0 +1,17 @@
+import { Container, SubText, TitleText } from './boxblock.styled';
+
+type Props = {
+  size: 'normal' | 'big';
+  color?: string;
+  titleText: string;
+  subText?: string;
+};
+
+export default function BoxBlock({ size, color, titleText, subText }: Props) {
+  return (
+    <Container color={color} size={size}>
+      <TitleText size={size}>{titleText}</TitleText>
+      {subText && <SubText size={size}>{subText}</SubText>}
+    </Container>
+  );
+}

--- a/components/farmer/boxBlock/boxblock.styled.ts
+++ b/components/farmer/boxBlock/boxblock.styled.ts
@@ -1,0 +1,33 @@
+import styled from 'styled-components/native';
+
+export const Container = styled.TouchableOpacity<{
+  color?: string;
+  size: 'normal' | 'big';
+}>`
+  background-color: ${({ color }) => (color ? color : '#d9d9d9')};
+  width: 160px;
+  height: ${({ size }) => (size === 'normal' ? '80px' : '160px')};
+  border-radius: 20px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 20px;
+  box-shadow: ${({ size }) =>
+    size === 'big' ? '0px 4px 12px rgba(0, 0, 0, 0.1)' : 'none'};
+  gap: 10px;
+`;
+
+export const TitleText = styled.Text<{
+  size: 'normal' | 'big';
+}>`
+  color: ${({ size }) => (size === 'normal' ? '#000' : '#fff')};
+  font-size: 18px;
+  font-weight: 800;
+`;
+
+export const SubText = styled.Text<{
+  size: 'normal' | 'big';
+}>`
+  color: ${({ size }) => (size === 'normal' ? '#000' : '#fff')};
+`;

--- a/components/farmer/featuresBox/FeaturesBox.tsx
+++ b/components/farmer/featuresBox/FeaturesBox.tsx
@@ -1,0 +1,28 @@
+import { Col, Container } from './featuresBox.styled';
+
+import BoxBlock from '../boxBlock/BoxBlock';
+
+export default function FeaturesBox() {
+  return (
+    <Container>
+      <Col>
+        <BoxBlock size='normal' titleText='이웃 농산물 보러가기' />
+        <BoxBlock
+          size='big'
+          titleText='농산물 판매하기'
+          subText='못난이 농산물을 이웃들에게 팔아 보세요'
+          color='#30DB5B'
+        />
+      </Col>
+      <Col>
+        <BoxBlock
+          size='big'
+          titleText='채팅하기'
+          subText='구매자와 대화한 내역을 확인해 볼 수 있어요'
+          color='#FFB340'
+        />
+        <BoxBlock size='normal' titleText='판매 목록' />
+      </Col>
+    </Container>
+  );
+}

--- a/components/farmer/featuresBox/featuresBox.styled.ts
+++ b/components/farmer/featuresBox/featuresBox.styled.ts
@@ -1,0 +1,18 @@
+import styled from 'styled-components/native';
+
+export const Container = styled.View`
+  width: 80%;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  gap: 20px;
+`;
+
+export const Col = styled.View`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 20px;
+`;

--- a/components/farmer/myFarm/MyFarm.tsx
+++ b/components/farmer/myFarm/MyFarm.tsx
@@ -1,0 +1,52 @@
+import * as Location from 'expo-location';
+
+import { useEffect, useState } from 'react';
+import { Container, LookMap, TitleText } from './myfarm.styled';
+
+import KakaoMap from '@/components/kakaomap/KakaoMap';
+import { useRouter } from 'expo-router';
+import { MoveDiagonal } from 'lucide-react-native';
+import { Text } from 'react-native';
+
+export default function MyFarm() {
+  const [location, setLocation] = useState<{
+    latitude: number;
+    longitude: number;
+  } | null>(null);
+  const router = useRouter();
+
+  const getCurrentLocation = async () => {
+    try {
+      const { status } = await Location.requestForegroundPermissionsAsync();
+      if (status !== 'granted') {
+        console.error('위치 권한이 거부되었습니다.');
+        return;
+      }
+
+      const { coords } = await Location.getCurrentPositionAsync({});
+      setLocation({
+        latitude: coords.latitude,
+        longitude: coords.longitude,
+      });
+    } catch (error) {
+      console.error('위치 정보를 가져오는 데 실패했습니다:', error);
+    }
+  };
+
+  useEffect(() => {
+    getCurrentLocation();
+  }, []);
+
+  return (
+    <Container>
+      <TitleText>내 농산물 재배 위치</TitleText>
+      {location && (
+        <KakaoMap latitude={location.latitude} longitude={location.longitude} />
+      )}
+      <LookMap onPress={() => router.push('/setFarmLocation')}>
+        <Text>지도 보기</Text>
+        <MoveDiagonal size={15} />
+      </LookMap>
+    </Container>
+  );
+}

--- a/components/farmer/myFarm/myfarm.styled.ts
+++ b/components/farmer/myFarm/myfarm.styled.ts
@@ -1,0 +1,30 @@
+import styled from 'styled-components/native';
+
+export const Container = styled.View`
+  width: 80%;
+  height: 200px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const TitleText = styled.Text`
+  font-size: 18px;
+  font-weight: 700;
+`;
+
+export const LookMap = styled.TouchableOpacity`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  background-color: #fff;
+  border: 1px solid #d9d9d9;
+  border-radius: 10px;
+  padding: 2px 5px;
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+`;

--- a/components/kakaomap/KakaoMap.tsx
+++ b/components/kakaomap/KakaoMap.tsx
@@ -1,0 +1,83 @@
+import { StyleSheet, View } from 'react-native';
+
+import React from 'react';
+import { KAKAO_MAP_JS_KEY } from 'react-native-dotenv';
+import { WebView } from 'react-native-webview';
+
+type KakaoMapProps = {
+  latitude?: number;
+  longitude?: number;
+};
+
+export default function KakaoMap({ latitude, longitude }: KakaoMapProps) {
+  const lat = latitude ?? 37.5665; // 기본 좌표(서울시청)
+  const lng = longitude ?? 126.978;
+
+  const html = `
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <meta charset="utf-8"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+        <style>
+          html, body { height:100%; margin:0; padding:0; }
+          #map { width:100%; height:100%; }
+        </style>
+        <!-- autoload=false 로드 -->
+        <script src="https://dapi.kakao.com/v2/maps/sdk.js?appkey=${KAKAO_MAP_JS_KEY}&autoload=false"></script>
+      </head>
+      <body>
+        <div id="map"></div>
+        <script>
+          kakao.maps.load(function () {
+            try {
+              var container = document.getElementById('map');
+              var options = {
+                center: new kakao.maps.LatLng(${lat}, ${lng}),
+                level: 3
+              };
+              var map = new kakao.maps.Map(container, options);
+              new kakao.maps.Marker({ position: new kakao.maps.LatLng(${lat}, ${lng}), map: map });
+              window.ReactNativeWebView && window.ReactNativeWebView.postMessage('KAKAO_READY');
+            } catch (e) {
+              window.ReactNativeWebView && window.ReactNativeWebView.postMessage('KAKAO_ERROR:' + e.message);
+            }
+          });
+        </script>
+      </body>
+    </html>
+  `;
+
+  return (
+    <View style={styles.container}>
+      <WebView
+        originWhitelist={['*']}
+        source={{
+          html,
+          // ★ Kakao 콘솔에 등록한 도메인으로 교체하세요
+          baseUrl: 'https://my-app.local',
+        }}
+        style={styles.webview}
+        javaScriptEnabled
+        domStorageEnabled
+        mixedContentMode='always'
+        onMessage={(e) => console.log('KakaoMap:', e.nativeEvent.data)}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    width: '100%',
+    marginTop: 20,
+    borderColor: '#d9d9d9',
+    borderWidth: 1,
+    borderRadius: 15,
+    overflow: 'hidden',
+  },
+  webview: {
+    flex: 1,
+  },
+});

--- a/components/seller/summaryBox/SummaryBox.tsx
+++ b/components/seller/summaryBox/SummaryBox.tsx
@@ -3,10 +3,20 @@ import { Container, ImageBox, InfoBox, TitleText } from './summaryBox.styled';
 import InfoItemBar from './infoItemBar/InfoItemBar';
 
 type Props = {
+  name: string;
   imgUrl: string;
+  userType: 'user' | 'farmer';
+  firstValue: string;
+  secondValue: string;
 };
 
-export default function SummaryBox({ imgUrl }: Props) {
+export default function SummaryBox({
+  name,
+  imgUrl,
+  userType,
+  firstValue,
+  secondValue,
+}: Props) {
   return (
     <Container>
       <ImageBox
@@ -17,9 +27,12 @@ export default function SummaryBox({ imgUrl }: Props) {
         }
       />
       <InfoBox>
-        <TitleText>홍길동</TitleText>
-        <InfoItemBar label='판매 건수' value='0개' />
-        <InfoItemBar label='평균 별점' value='5점' />
+        <TitleText>{name}</TitleText>
+        <InfoItemBar label='판매 건수' value={firstValue} />
+        <InfoItemBar
+          label={userType === 'user' ? '평균 별점' : '판매 수익'}
+          value={secondValue}
+        />
       </InfoBox>
     </Container>
   );

--- a/components/seller/summaryBox/summaryBox.styled.ts
+++ b/components/seller/summaryBox/summaryBox.styled.ts
@@ -2,7 +2,6 @@ import { Image } from 'react-native';
 import styled from 'styled-components/native';
 
 export const Container = styled.View`
-  margin: auto;
   width: 90%;
   height: 130px;
   border-radius: 15px;

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "expo-image": "~2.4.0",
         "expo-image-picker": "~16.1.4",
         "expo-linking": "~7.1.7",
+        "expo-location": "^18.1.6",
         "expo-router": "~5.1.4",
         "expo-splash-screen": "~0.30.10",
         "expo-status-bar": "~2.2.3",
@@ -33,6 +34,7 @@
         "react": "19.0.0",
         "react-dom": "19.0.0",
         "react-native": "0.79.5",
+        "react-native-dotenv": "^3.4.11",
         "react-native-gesture-handler": "~2.24.0",
         "react-native-ratings": "^8.1.0",
         "react-native-reanimated": "~3.17.4",
@@ -40,7 +42,7 @@
         "react-native-screens": "~4.11.1",
         "react-native-svg": "^15.12.1",
         "react-native-web": "~0.20.0",
-        "react-native-webview": "13.13.5",
+        "react-native-webview": "^13.13.5",
         "styled-components": "^6.1.19"
       },
       "devDependencies": {
@@ -7329,6 +7331,15 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-location": {
+      "version": "18.1.6",
+      "resolved": "https://registry.npmjs.org/expo-location/-/expo-location-18.1.6.tgz",
+      "integrity": "sha512-l5dQQ2FYkrBgNzaZN1BvSmdhhcztFOUucu2kEfDBMV4wSIuTIt/CKsho+F3RnAiWgvui1wb1WTTf80E8zq48hA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-modules-autolinking": {
       "version": "2.1.14",
       "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-2.1.14.tgz",
@@ -11299,6 +11310,18 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-native-dotenv": {
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/react-native-dotenv/-/react-native-dotenv-3.4.11.tgz",
+      "integrity": "sha512-6vnIE+WHABSeHCaYP6l3O1BOEhWxKH6nHAdV7n/wKn/sciZ64zPPp2NUdEUf1m7g4uuzlLbjgr+6uDt89q2DOg==",
+      "license": "MIT",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
+      "peerDependencies": {
+        "@babel/runtime": "^7.20.6"
       }
     },
     "node_modules/react-native-edge-to-edge": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "expo-image": "~2.4.0",
     "expo-image-picker": "~16.1.4",
     "expo-linking": "~7.1.7",
+    "expo-location": "^18.1.6",
     "expo-router": "~5.1.4",
     "expo-splash-screen": "~0.30.10",
     "expo-status-bar": "~2.2.3",
@@ -36,6 +37,7 @@
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-native": "0.79.5",
+    "react-native-dotenv": "^3.4.11",
     "react-native-gesture-handler": "~2.24.0",
     "react-native-ratings": "^8.1.0",
     "react-native-reanimated": "~3.17.4",
@@ -43,7 +45,7 @@
     "react-native-screens": "~4.11.1",
     "react-native-svg": "^15.12.1",
     "react-native-web": "~0.20.0",
-    "react-native-webview": "13.13.5",
+    "react-native-webview": "^13.13.5",
     "styled-components": "^6.1.19"
   },
   "devDependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,15 +3,14 @@
   "compilerOptions": {
     "strict": true,
     "paths": {
-      "@/*": [
-        "./*"
-      ]
+      "@/*": ["./*"]
     }
   },
   "include": [
     "**/*.ts",
     "**/*.tsx",
     ".expo/types/**/*.ts",
-    "expo-env.d.ts"
+    "expo-env.d.ts",
+    "babel.config.ks"
   ]
 }

--- a/types/react-native-dotenv.d.ts
+++ b/types/react-native-dotenv.d.ts
@@ -1,0 +1,3 @@
+declare module 'react-native-dotenv' {
+  export const KAKAO_MAP_JS_KEY: string;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #17 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 농민 메인 페이지 UI 퍼블리싱
- 버튼 컴포넌트 동적 사이즈 적용 구성

### 스크린샷
| 화면 | 스크린샷 |
|------|-----------|
| 농부 메인 페이지 | <img src="https://github.com/user-attachments/assets/14636ce5-6e2b-4378-bb2a-b4e88ec9425e" width="300"/> |

## 💬리뷰 요구사항(선택)

> 카카오맵 API 를 불러오는 컴포넌트가 문제가 있습니다.
> 카카오맵 부분은 별도 이슈로 분리하여 추후에 작업할 예정입니다.