### PR TITLE
[Feat] 판매 목록 페이지 및 관련 페이지 UI 퍼블리싱

### DIFF
--- a/app/sell-list/[id].tsx
+++ b/app/sell-list/[id].tsx
@@ -1,0 +1,64 @@
+import { useLocalSearchParams, useRouter } from 'expo-router';
+
+import Button from '@/components/common/button/Button';
+import ImageSlideBox from '@/components/itemDetail/imageSlideBox/ImageSlideBox';
+import InfoBox from '@/components/itemDetail/infoBox/InfoBox';
+import TopBar from '@/components/itemDetail/topBar/TopBar';
+import { useActionSheet } from '@expo/react-native-action-sheet';
+import { Container } from './sellsListDetail.styled';
+
+export default function SellsListDetail() {
+  const { id } = useLocalSearchParams();
+  const router = useRouter();
+  const { showActionSheetWithOptions } = useActionSheet();
+
+  const handlePress = () => {
+    const options = ['거래완료', '수정하기', '삭제하기', '닫기'];
+    const destructiveButtonIndex = 2;
+    const cancelButtonIndex = 3;
+
+    showActionSheetWithOptions(
+      {
+        options,
+        cancelButtonIndex,
+        destructiveButtonIndex,
+      },
+      (buttonIndex) => {
+        switch (buttonIndex) {
+          case 0:
+            console.log('거래완료 선택됨');
+            // TODO: 완료 처리 로직
+            break;
+          case 1:
+            router.push(`/sell-list/${id}/edit`);
+            break;
+          case 2:
+            console.log('삭제하기 선택됨');
+            // TODO: 삭제 확인 및 실행
+            break;
+          default:
+            break;
+        }
+      }
+    );
+  };
+
+  return (
+    <Container>
+      <TopBar onMorePress={handlePress} />
+      <ImageSlideBox price='19000' />
+      <InfoBox
+        sellerId={'dd'}
+        title='제목'
+        description='설명'
+        imgUrl=''
+        marketName='홍길동'
+        rating='5.0'
+      />
+      <Button
+        onClick={() => router.push(`/sell-list/${id}/edit`)}
+        text='수정하기'
+      />
+    </Container>
+  );
+}

--- a/app/sell-list/[id]/edit.tsx
+++ b/app/sell-list/[id]/edit.tsx
@@ -1,14 +1,29 @@
-import { useLocalSearchParams } from 'expo-router';
-import { Text } from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+
+import Button from '@/components/common/button/Button';
+import EditItemContent from '@/components/farmer/editItemContent/EditItemContent';
+import LevelAndGoHome from '@/components/farmer/levelAndGoHome/LevelAndGoHome';
+import ImageSlideBox from '@/components/itemDetail/imageSlideBox/ImageSlideBox';
+import { useState } from 'react';
 import { Container } from './editItem.styled';
 
 export default function EditItem() {
   const { id } = useLocalSearchParams();
+  const [title, setTitle] = useState<string>('예시 제목');
+  const [content, setContent] = useState<string>('예시 내용들 블라블라');
+  const router = useRouter();
 
   return (
     <Container>
-      <Text>this is Edit page</Text>
-      <Text>{id}</Text>
+      <LevelAndGoHome level={3} />
+      <ImageSlideBox price='19000' />
+      <EditItemContent
+        title={title}
+        setTitle={setTitle}
+        content={content}
+        setContent={setContent}
+      />
+      <Button onClick={() => router.back()} text='작성 완료' />
     </Container>
   );
 }

--- a/app/sell-list/[id]/edit.tsx
+++ b/app/sell-list/[id]/edit.tsx
@@ -1,0 +1,14 @@
+import { useLocalSearchParams } from 'expo-router';
+import { Text } from 'react-native';
+import { Container } from './editItem.styled';
+
+export default function EditItem() {
+  const { id } = useLocalSearchParams();
+
+  return (
+    <Container>
+      <Text>this is Edit page</Text>
+      <Text>{id}</Text>
+    </Container>
+  );
+}

--- a/app/sell-list/[id]/editItem.styled.ts
+++ b/app/sell-list/[id]/editItem.styled.ts
@@ -1,0 +1,7 @@
+import { SafeAreaView } from 'react-native-safe-area-context';
+import styled from 'styled-components/native';
+
+export const Container = styled(SafeAreaView)`
+  width: 100%;
+  flex: 1;
+`;

--- a/app/sell-list/index.tsx
+++ b/app/sell-list/index.tsx
@@ -1,0 +1,12 @@
+import BackAndTitle from '@/components/common/backAndTitle/BackAndTitle';
+import { Text } from 'react-native';
+import { Container } from './sellList.styled';
+
+export default function SellList() {
+  return (
+    <Container>
+      <BackAndTitle title='판매 목록' />
+      <Text>HI</Text>
+    </Container>
+  );
+}

--- a/app/sell-list/index.tsx
+++ b/app/sell-list/index.tsx
@@ -1,4 +1,6 @@
 import BackAndTitle from '@/components/common/backAndTitle/BackAndTitle';
+import SellListBox from '@/components/farmer/sell-list/sellListBox/SellListBox';
+import TopOptionBar from '@/components/farmer/sell-list/topOptionBar/TopOptionBar';
 import { Text } from 'react-native';
 import { Container } from './sellList.styled';
 
@@ -6,6 +8,8 @@ export default function SellList() {
   return (
     <Container>
       <BackAndTitle title='판매 목록' />
+      <TopOptionBar />
+      <SellListBox />
       <Text>HI</Text>
     </Container>
   );

--- a/app/sell-list/index.tsx
+++ b/app/sell-list/index.tsx
@@ -1,7 +1,6 @@
 import BackAndTitle from '@/components/common/backAndTitle/BackAndTitle';
 import SellListBox from '@/components/farmer/sell-list/sellListBox/SellListBox';
 import TopOptionBar from '@/components/farmer/sell-list/topOptionBar/TopOptionBar';
-import { Text } from 'react-native';
 import { Container } from './sellList.styled';
 
 export default function SellList() {
@@ -10,7 +9,6 @@ export default function SellList() {
       <BackAndTitle title='판매 목록' />
       <TopOptionBar />
       <SellListBox />
-      <Text>HI</Text>
     </Container>
   );
 }

--- a/app/sell-list/sellList.styled.ts
+++ b/app/sell-list/sellList.styled.ts
@@ -1,0 +1,4 @@
+import { SafeAreaView } from 'react-native-safe-area-context';
+import styled from 'styled-components/native';
+
+export const Container = styled(SafeAreaView)``;

--- a/app/sell-list/sellList.styled.ts
+++ b/app/sell-list/sellList.styled.ts
@@ -1,4 +1,12 @@
 import { SafeAreaView } from 'react-native-safe-area-context';
 import styled from 'styled-components/native';
 
-export const Container = styled(SafeAreaView)``;
+export const Container = styled(SafeAreaView)`
+  width: 100%;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  background-color: #fff;
+`;

--- a/app/sell-list/sellsListDetail.styled.ts
+++ b/app/sell-list/sellsListDetail.styled.ts
@@ -1,7 +1,9 @@
 import { SafeAreaView } from 'react-native-safe-area-context';
 import styled from 'styled-components/native';
 
-export const Container = styled(SafeAreaView)`
+export const Container = styled(SafeAreaView).attrs({
+  edges: ['bottom', 'left', 'right'],
+})`
   width: 100%;
   flex: 1;
   display: flex;

--- a/app/sell-list/sellsListDetail.styled.ts
+++ b/app/sell-list/sellsListDetail.styled.ts
@@ -8,4 +8,5 @@ export const Container = styled(SafeAreaView)`
   flex-direction: column;
   justify-content: flex-start;
   align-items: center;
+  background-color: #fff;
 `;

--- a/app/sell-list/sellsListDetail.styled.ts
+++ b/app/sell-list/sellsListDetail.styled.ts
@@ -6,8 +6,6 @@ export const Container = styled(SafeAreaView)`
   flex: 1;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  justify-content: flex-start;
   align-items: center;
-  background-color: #fff;
-  gap: 10px;
 `;

--- a/components/common/underLineBar/UnderLineBar.tsx
+++ b/components/common/underLineBar/UnderLineBar.tsx
@@ -1,0 +1,5 @@
+import { Container } from './underLineBar.styled';
+
+export default function UnderLineBar() {
+  return <Container></Container>;
+}

--- a/components/common/underLineBar/underLineBar.styled.ts
+++ b/components/common/underLineBar/underLineBar.styled.ts
@@ -1,0 +1,7 @@
+import styled from 'styled-components/native';
+
+export const Container = styled.View`
+  width: 100%;
+  height: 1px;
+  border: 1px solid #d9d9d9;
+`;

--- a/components/farmer/boxBlock/boxblock.styled.ts
+++ b/components/farmer/boxBlock/boxblock.styled.ts
@@ -4,10 +4,10 @@ export const Container = styled.TouchableOpacity<{
   color?: string;
   size: 'normal' | 'big';
 }>`
-  background-color: ${({ color }) => (color ? color : '#d9d9d9')};
+  background-color: ${({ color }) => (color ? color : '#f5f5f5')};
   width: 160px;
   height: ${({ size }) => (size === 'normal' ? '80px' : '160px')};
-  border-radius: 20px;
+  border-radius: 15px;
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/components/farmer/editItemContent/EditItemContent.tsx
+++ b/components/farmer/editItemContent/EditItemContent.tsx
@@ -1,0 +1,25 @@
+import { Container, ContentText, TitleText } from './editItemContent.styled';
+
+import UnderLine from '@/components/common/underLineBar/UnderLineBar';
+
+type Props = {
+  title: string;
+  setTitle: (title: string) => void;
+  content: string;
+  setContent: (content: string) => void;
+};
+
+export default function EditItemContent({
+  title,
+  setTitle,
+  content,
+  setContent,
+}: Props) {
+  return (
+    <Container>
+      <TitleText onChangeText={setTitle}>{title}</TitleText>
+      <UnderLine />
+      <ContentText onChangeText={setContent}>{content}</ContentText>
+    </Container>
+  );
+}

--- a/components/farmer/editItemContent/editItemContent.styled.ts
+++ b/components/farmer/editItemContent/editItemContent.styled.ts
@@ -1,0 +1,27 @@
+import styled from 'styled-components/native';
+
+export const Container = styled.View`
+  padding: 20px 10px;
+  width: 80%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 10px;
+`;
+
+export const TitleText = styled.TextInput`
+  width: 100%;
+  font-size: 18px;
+  font-weight: 800;
+`;
+
+export const ContentText = styled.TextInput.attrs({
+  multiline: true,
+  textAlignVertical: 'top',
+})`
+  width: 100%;
+  height: 200px;
+  text-align: start;
+  font-size: 16px;
+`;

--- a/components/farmer/featuresBox/FeaturesBox.tsx
+++ b/components/farmer/featuresBox/FeaturesBox.tsx
@@ -1,8 +1,8 @@
 import { Col, Container } from './featuresBox.styled';
 
-import BoxBlock from '../boxBlock/BoxBlock';
-import { useRouter } from 'expo-router';
 import { useUserStore } from '@/store/userStore';
+import { useRouter } from 'expo-router';
+import BoxBlock from '../boxBlock/BoxBlock';
 
 export default function FeaturesBox() {
   const router = useRouter();
@@ -35,7 +35,7 @@ export default function FeaturesBox() {
           color='#FFB340'
         />
         <BoxBlock
-          onPress={() => console.log('판매 목록 페이지 이동')}
+          onPress={() => router.push('/sell-list')}
           size='normal'
           titleText='판매 목록'
         />

--- a/components/farmer/levelAndGoHome/LevelAndGoHome.tsx
+++ b/components/farmer/levelAndGoHome/LevelAndGoHome.tsx
@@ -1,0 +1,23 @@
+import { Container, GoHomeButton, StyledText } from './levelAndGoHome.styled';
+
+import { useRouter } from 'expo-router';
+import OneTwoThreeLevel from '../oneToThreeLevel/OneToThreeLevel';
+
+type Props = {
+  level: 1 | 2 | 3;
+};
+
+export default function LevelAndGoHome({ level }: Props) {
+  const router = useRouter();
+
+  return (
+    <Container>
+      <OneTwoThreeLevel level={level} />
+      <GoHomeButton>
+        <StyledText onPress={() => router.push('/farmer')}>
+          홈으로 이동
+        </StyledText>
+      </GoHomeButton>
+    </Container>
+  );
+}

--- a/components/farmer/levelAndGoHome/levelAndGoHome.styled.ts
+++ b/components/farmer/levelAndGoHome/levelAndGoHome.styled.ts
@@ -1,12 +1,17 @@
 import styled from 'styled-components/native';
 
 export const Container = styled.View`
-  width: 80%;
+  width: 100%;
+  padding: 30px;
   height: 80px;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
+  position: absolute;
+  top: 50px;
+  z-index: 2;
+  background-color: #fff;
 `;
 
 export const GoHomeButton = styled.TouchableOpacity`

--- a/components/farmer/levelAndGoHome/levelAndGoHome.styled.ts
+++ b/components/farmer/levelAndGoHome/levelAndGoHome.styled.ts
@@ -1,0 +1,27 @@
+import styled from 'styled-components/native';
+
+export const Container = styled.View`
+  width: 80%;
+  height: 80px;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+export const GoHomeButton = styled.TouchableOpacity`
+  background-color: #30db5b;
+  width: 120px;
+  height: 50px;
+  border-radius: 15px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const StyledText = styled.Text`
+  font-size: 16px;
+  font-weight: 700;
+  color: #fff;
+`;

--- a/components/farmer/oneToThreeLevel/OneToThreeLevel.tsx
+++ b/components/farmer/oneToThreeLevel/OneToThreeLevel.tsx
@@ -1,0 +1,28 @@
+import {
+  CircleTextWraaper,
+  Container,
+  Divider,
+  StyledText,
+} from './oneToThreeLevel.styled';
+
+type Props = {
+  level: 1 | 2 | 3;
+};
+
+export default function OneTwoThreeLevel({ level }: Props) {
+  return (
+    <Container>
+      <CircleTextWraaper isSelected={level === 1}>
+        <StyledText isSelected={level === 1}>1</StyledText>
+      </CircleTextWraaper>
+      <Divider />
+      <CircleTextWraaper isSelected={level === 2}>
+        <StyledText isSelected={level === 2}>2</StyledText>
+      </CircleTextWraaper>
+      <Divider />
+      <CircleTextWraaper isSelected={level === 3}>
+        <StyledText isSelected={level === 3}>3</StyledText>
+      </CircleTextWraaper>
+    </Container>
+  );
+}

--- a/components/farmer/oneToThreeLevel/oneToThreeLevel.styled.ts
+++ b/components/farmer/oneToThreeLevel/oneToThreeLevel.styled.ts
@@ -1,0 +1,33 @@
+import styled from 'styled-components/native';
+
+export const Container = styled.View`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  gap: 5px;
+`;
+
+export const CircleTextWraaper = styled.View<{ isSelected: boolean }>`
+  border: 1px solid #d9d9d9;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: ${({ isSelected }) => (isSelected ? '#30DB5B' : '#fff')};
+`;
+
+export const Divider = styled.View`
+  width: 15px;
+  height: 1px;
+  border-style: dotted;
+  border-width: 1px;
+  border-color: #999;
+`;
+
+export const StyledText = styled.Text<{ isSelected: boolean }>`
+  color: ${({ isSelected }) => (isSelected ? '#fff' : '')};
+  font-weight: 700;
+`;

--- a/components/farmer/sell-list/manageButton/ManageButton.tsx
+++ b/components/farmer/sell-list/manageButton/ManageButton.tsx
@@ -1,0 +1,18 @@
+import { EllipsisVertical, Trash } from 'lucide-react-native';
+
+import { Container } from './manageButton.styled';
+
+type Props = {
+  isCompleted: boolean;
+  onEditPress: () => void;
+};
+
+export default function ManageButton({ isCompleted, onEditPress }: Props) {
+  return (
+    <Container
+      onPress={isCompleted ? () => console.log('삭제버튼') : onEditPress}
+    >
+      {isCompleted ? <Trash color='#fff' /> : <EllipsisVertical color='#fff' />}
+    </Container>
+  );
+}

--- a/components/farmer/sell-list/manageButton/manageButton.styled.ts
+++ b/components/farmer/sell-list/manageButton/manageButton.styled.ts
@@ -1,0 +1,11 @@
+import styled from 'styled-components/native';
+
+export const Container = styled.TouchableOpacity`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background-color: #30db5b;
+  padding: 10px;
+  border-radius: 50%;
+`;

--- a/components/farmer/sell-list/optionElement/OptionElement.tsx
+++ b/components/farmer/sell-list/optionElement/OptionElement.tsx
@@ -1,0 +1,29 @@
+import { BoldText, Container, LabelText, Row } from './optionElement.styled';
+
+import { Dot } from 'lucide-react-native';
+
+type Props = {
+  label: string;
+  value: string;
+  selected?: boolean;
+  option: 'numOfSells' | 'numOfComplete';
+  setOption: (option: 'numOfSells' | 'numOfComplete') => void;
+};
+
+export default function OptionElement({
+  label,
+  value,
+  selected,
+  option,
+  setOption,
+}: Props) {
+  return (
+    <Container onPress={() => setOption(option)} selected={selected || false}>
+      <Row>
+        <Dot color={selected ? '#30DB5B' : '#d9d9d9'} />
+        <LabelText>{label}</LabelText>
+      </Row>
+      <BoldText>{value}</BoldText>
+    </Container>
+  );
+}

--- a/components/farmer/sell-list/optionElement/optionElement.styled.ts
+++ b/components/farmer/sell-list/optionElement/optionElement.styled.ts
@@ -1,0 +1,27 @@
+import styled from 'styled-components/native';
+
+export const Container = styled.TouchableOpacity<{ selected: boolean }>`
+  width: 45%;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+  align-items: center;
+  border-radius: 20px;
+  padding: 8px;
+  border: 1px solid #d9d9d9;
+  border-color: ${({ selected }) => (selected ? '#30DB5B' : '#d9d9d9')};
+`;
+
+export const Row = styled.View`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const LabelText = styled.Text``;
+
+export const BoldText = styled.Text`
+  font-size: 16px;
+  font-weight: 800;
+`;

--- a/components/farmer/sell-list/overlayImage/OverlayImage.tsx
+++ b/components/farmer/sell-list/overlayImage/OverlayImage.tsx
@@ -1,0 +1,18 @@
+import { Container, Overlay, OverlayText } from './overlayImage.styled';
+
+type Props = {
+  isCompledted: boolean;
+  source: any;
+};
+
+export default function OverlayImage({ isCompledted, source }: Props) {
+  return (
+    <Container>
+      {isCompledted && (
+        <Overlay>
+          <OverlayText>거래 완료</OverlayText>
+        </Overlay>
+      )}
+    </Container>
+  );
+}

--- a/components/farmer/sell-list/overlayImage/overlayImage.styled.ts
+++ b/components/farmer/sell-list/overlayImage/overlayImage.styled.ts
@@ -1,0 +1,23 @@
+import { ImageBackground, Text, View } from 'react-native';
+
+import styled from 'styled-components/native';
+
+export const Container = styled(ImageBackground)`
+  width: 80px;
+  height: 80px;
+  border-radius: 15px;
+  overflow: hidden;
+`;
+
+export const Overlay = styled(View)`
+  flex: 1;
+  background-color: rgba(0, 0, 0, 0.4); /* 흐림 효과 */
+  justify-content: center;
+  align-items: center;
+`;
+
+export const OverlayText = styled(Text)`
+  color: white;
+  font-weight: bold;
+  font-size: 14px;
+`;

--- a/components/farmer/sell-list/sellListBox/SellListBox.tsx
+++ b/components/farmer/sell-list/sellListBox/SellListBox.tsx
@@ -1,0 +1,13 @@
+import { sellsDummyData } from '@/mocks/sells-list-mocks';
+import SellListItem from '../sellListItem/SellListItem';
+import { Container } from './sellListBox.styled';
+
+export default function SellListBox() {
+  return (
+    <Container>
+      {sellsDummyData.map((data, index) => (
+        <SellListItem key={index} {...data} itemId='2' />
+      ))}
+    </Container>
+  );
+}

--- a/components/farmer/sell-list/sellListBox/sellListBox.styled.ts
+++ b/components/farmer/sell-list/sellListBox/sellListBox.styled.ts
@@ -1,0 +1,10 @@
+import styled from 'styled-components/native';
+
+export const Container = styled.View`
+  width: 80%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+`;

--- a/components/farmer/sell-list/sellListItem/SellListItem.tsx
+++ b/components/farmer/sell-list/sellListItem/SellListItem.tsx
@@ -49,8 +49,7 @@ export default function SellListItem({
             // TODO: 완료 처리 로직
             break;
           case 1:
-            console.log('수정하기 선택됨');
-            // TODO: 수정 화면으로 이동
+            router.push(`/sell-list/${itemId}/edit`);
             break;
           case 2:
             console.log('삭제하기 선택됨');

--- a/components/farmer/sell-list/sellListItem/SellListItem.tsx
+++ b/components/farmer/sell-list/sellListItem/SellListItem.tsx
@@ -1,0 +1,79 @@
+import {
+  Col,
+  Container,
+  FarmerNameText,
+  ItemNameText,
+  PriceText,
+  Row,
+} from './sellListItem.styled';
+
+import { useActionSheet } from '@expo/react-native-action-sheet';
+import { useRouter } from 'expo-router';
+import ManageButton from '../manageButton/ManageButton';
+import OverlayImage from '../overlayImage/OverlayImage';
+
+type Props = {
+  itemImg: string;
+  itemName: string;
+  price: string;
+  farmerName: string;
+  isCompleted: boolean;
+  itemId: string;
+};
+
+export default function SellListItem({
+  itemImg,
+  itemName,
+  price,
+  farmerName,
+  isCompleted,
+  itemId,
+}: Props) {
+  const { showActionSheetWithOptions } = useActionSheet();
+  const router = useRouter();
+  const handlePress = () => {
+    const options = ['거래완료', '수정하기', '삭제하기', '취소'];
+    const destructiveButtonIndex = 2;
+    const cancelButtonIndex = 3;
+
+    showActionSheetWithOptions(
+      {
+        options,
+        cancelButtonIndex,
+        destructiveButtonIndex,
+      },
+      (buttonIndex) => {
+        switch (buttonIndex) {
+          case 0:
+            console.log('거래완료 선택됨');
+            // TODO: 완료 처리 로직
+            break;
+          case 1:
+            console.log('수정하기 선택됨');
+            // TODO: 수정 화면으로 이동
+            break;
+          case 2:
+            console.log('삭제하기 선택됨');
+            // TODO: 삭제 확인 및 실행
+            break;
+          default:
+            break;
+        }
+      }
+    );
+  };
+
+  return (
+    <Container onPress={() => router.push(`/sell-list/${itemId}`)}>
+      <Row>
+        <OverlayImage isCompledted={isCompleted} source={itemImg} />
+        <Col>
+          <ItemNameText>{itemName}</ItemNameText>
+          <PriceText>{price}</PriceText>
+          <FarmerNameText>{farmerName}</FarmerNameText>
+        </Col>
+      </Row>
+      <ManageButton isCompleted={isCompleted} onEditPress={handlePress} />
+    </Container>
+  );
+}

--- a/components/farmer/sell-list/sellListItem/sellListItem.styled.ts
+++ b/components/farmer/sell-list/sellListItem/sellListItem.styled.ts
@@ -1,0 +1,45 @@
+import { Image } from 'react-native';
+import styled from 'styled-components/native';
+
+export const Container = styled.TouchableOpacity`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+export const Row = styled.View`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  gap: 15px;
+`;
+
+export const Col = styled.View`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 3px;
+`;
+
+export const ImageBox = styled(Image)<{ isCompleted: boolean }>`
+  width: 80px;
+  height: 80px;
+  border-radius: 15px;
+`;
+
+export const ItemNameText = styled.Text`
+  font-weight: 600;
+`;
+
+export const PriceText = styled.Text`
+  font-size: 15px;
+  font-weight: 800;
+`;
+
+export const FarmerNameText = styled.Text`
+  font-weight: 500;
+`;

--- a/components/farmer/sell-list/topOptionBar/TopOptionBar.tsx
+++ b/components/farmer/sell-list/topOptionBar/TopOptionBar.tsx
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+import OptionElement from '../optionElement/OptionElement';
+import { Container } from './topOptionBar.styled';
+
+export default function TopOptionBar() {
+  const [option, setOption] = useState<'numOfSells' | 'numOfComplete'>(
+    'numOfSells'
+  );
+
+  return (
+    <Container>
+      <OptionElement
+        label='총 판매 개수'
+        value='5개'
+        option='numOfSells'
+        setOption={setOption}
+        selected={option === 'numOfSells'}
+      />
+      <OptionElement
+        label='거래 완료 개수'
+        value='0개'
+        option='numOfComplete'
+        setOption={setOption}
+        selected={option === 'numOfComplete'}
+      />
+    </Container>
+  );
+}

--- a/components/farmer/sell-list/topOptionBar/topOptionBar.styled.ts
+++ b/components/farmer/sell-list/topOptionBar/topOptionBar.styled.ts
@@ -1,0 +1,11 @@
+import styled from 'styled-components/native';
+
+export const Container = styled.View`
+  height: 100px;
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+`;

--- a/components/farmer/sell-list/topOptionBar/topOptionBar.styled.ts
+++ b/components/farmer/sell-list/topOptionBar/topOptionBar.styled.ts
@@ -2,7 +2,7 @@ import styled from 'styled-components/native';
 
 export const Container = styled.View`
   height: 100px;
-  width: 100%;
+  width: 90%;
   display: flex;
   flex-direction: row;
   justify-content: center;

--- a/components/itemDetail/topBar/TopBar.tsx
+++ b/components/itemDetail/topBar/TopBar.tsx
@@ -7,6 +7,7 @@ import {
   StyledHomeIcon,
 } from './topBar.styled';
 
+import { useUserStore } from '@/store/userStore';
 import { useRouter } from 'expo-router';
 
 type Props = {
@@ -15,6 +16,7 @@ type Props = {
 
 export default function TopBar({ onMorePress }: Props) {
   const router = useRouter();
+  const userType = useUserStore((state) => state.userType);
 
   return (
     <Container>
@@ -22,7 +24,11 @@ export default function TopBar({ onMorePress }: Props) {
         <ButtonWrapper onPress={() => router.back()}>
           <StyledBeforeIcon />
         </ButtonWrapper>
-        <ButtonWrapper onPress={() => router.replace('/user')}>
+        <ButtonWrapper
+          onPress={() =>
+            router.replace(userType === 'user' ? '/user' : '/farmer')
+          }
+        >
           <StyledHomeIcon />
         </ButtonWrapper>
       </LeftSection>

--- a/mocks/sells-list-mocks.ts
+++ b/mocks/sells-list-mocks.ts
@@ -1,0 +1,45 @@
+type Props = {
+  itemImg: string;
+  itemName: string;
+  price: string;
+  farmerName: string;
+  isCompleted: boolean;
+};
+
+export const sellsDummyData: Props[] = [
+  {
+    itemImg: '',
+    itemName: '유기농 사과 5kg',
+    price: '25000',
+    farmerName: '김철수',
+    isCompleted: true,
+  },
+  {
+    itemImg: '',
+    itemName: '참외 3kg',
+    price: '18000',
+    farmerName: '박영희',
+    isCompleted: false,
+  },
+  {
+    itemImg: '',
+    itemName: '감자 10kg',
+    price: '30000',
+    farmerName: '이민수',
+    isCompleted: true,
+  },
+  {
+    itemImg: '',
+    itemName: '방울토마토 2kg',
+    price: '15000',
+    farmerName: '최지훈',
+    isCompleted: false,
+  },
+  {
+    itemImg: '',
+    itemName: '시금치 1kg',
+    price: '8000',
+    farmerName: '정하늘',
+    isCompleted: true,
+  },
+];


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #20 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 판매 목록 페이지 UI 퍼블리싱
- 거래 완료 이미지 컴포넌트 생성
- 판매 목록 상세 페이지 UI 퍼블리싱
- 판매 상품 수정 페이지 UI 퍼블리싱
- 관련 컴포넌트들 생성 및 적용

### 스크린샷
| 화면 | 스크린샷 |
|------|-----------|
| 판매 목록 페이지 | <img src="https://github.com/user-attachments/assets/52dc4352-85ac-4e01-94b6-5530e9e6959e" width="300"/> |
|------|-----------|
| 판매 목록 상세 페이지 | <img src="https://github.com/user-attachments/assets/ad355084-6a66-4ff9-bf18-9e83883e919b" width="300"/> |
|------|-----------|
| 판매 수정 페이지 | <img src="https://github.com/user-attachments/assets/d8b80e40-e03f-40ab-a95a-14a7f19b2967" width="300"/> |


