### PR TITLE
[Fix] 로그아웃 후 메인으로 이동하지 않는 문제 수정

### DIFF
--- a/app/sign-in/index.tsx
+++ b/app/sign-in/index.tsx
@@ -7,14 +7,21 @@ import {
   TitleImg,
 } from './Signin.styles';
 
-import React from 'react';
-import TitleSvg from '../../assets/images/title.svg';
-import { TouchableOpacity } from 'react-native';
 import { socialLogin } from '@/services/auth.service';
+import { Stack } from 'expo-router';
+import React from 'react';
+import { TouchableOpacity } from 'react-native';
+import TitleSvg from '../../assets/images/title.svg';
 
 export default function SigninScreen() {
   return (
     <Container>
+      <Stack.Screen
+        options={{
+          gestureEnabled: false,
+          headerBackVisible: false,
+        }}
+      />
       <TitleImg>
         <TitleSvg width='100%' />
       </TitleImg>

--- a/components/profile/myProfileSum/MyProfileSum.tsx
+++ b/components/profile/myProfileSum/MyProfileSum.tsx
@@ -1,3 +1,4 @@
+import { Text, TouchableOpacity } from 'react-native';
 import {
   Column,
   Container,
@@ -9,11 +10,10 @@ import {
   UserTypeText,
   WhiteText,
 } from './myProfileSum.styled';
-import { Text, TouchableOpacity } from 'react-native';
 
 import { logout } from '@/services/auth.service';
-import { useRouter } from 'expo-router';
 import { useUserStore } from '@/store/userStore';
+import { useRouter } from 'expo-router';
 
 type Props = {
   name: string;
@@ -45,7 +45,7 @@ export default function MyProfileSum({ name, profileImgUrl }: Props) {
               onPress={() => {
                 logout();
                 useUserStore.getState().logout();
-                router.replace('/');
+                router.replace('/sign-in');
               }}
             >
               <Text>로그아웃</Text>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #42 

## 📝작업 내용

> 로그아웃 시 router.replace를 통해 루트 디렉터리('/')로 이동하도록 해두었는데, 루트 컴포넌트에서는 상태를 확인하여 Redirect를 수행하기 때문에 비동기적으로 Zustand의 정보가 지워지기 전에 userType을 받아오려다 에러가 발생하는 듯.
> 따라서 바로 sign-in 페이지로 이동하도록 수정.
> 또한 로그아웃 후 sign-in 페이지로 이동하고 나서 제스쳐로 인한 뒤로가기를 수행하면, 로그인 정보가 없는 상태에서 본인 프로필이 조회되기 때문에 sign-in 페이지에서 제스쳐를 막음


## 💬리뷰 요구사항(선택)

> 없
